### PR TITLE
Add an "agreement" challenge

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1041,6 +1041,42 @@ type (required, string):
 
 To validate a DNS challenge, the server queries for TXT records under the validation domain name.  If it receives a record whose contents match the token in the challenge, then the validation succeeds.  Otherwise, the validation fails.
 
+## Subscriber Agreement / Terms of Use
+
+Some CAs require an applicant for a certificate to agree to a "subscriber agreement" or "terms of use".  In ACME, this requirement is can be expressed using the "agreement" challenge.  The challenge message includes a link to the agreement, in human-readable form.
+
+type (required, string):
+: The string "agreement"
+
+href (required, string):
+: An HTTP or HTTPS URI from which the agreement can be fetched, in human-readable form.
+
+~~~~~~~~~~
+
+{
+  "type": "dns",
+  "href": "https://example.com/acme/terms/"
+}
+
+~~~~~~~~~~
+
+If the user agrees to the referenced agreement, the client indicates its agreement in its response to the challenge.
+
+type (required, string):
+: The string "dns"
+
+agreed (required, boolean):
+: This value is set to "true" to indicate agreement, and "false" otherwise.
+
+~~~~~~~~~~
+
+{
+  "type": "agreement",
+  "agreed": true
+}
+
+~~~~~~~~~~
+
 
 ## Other possibilities
 


### PR DESCRIPTION
The [CABF Baseline Requirements (Section 10.3.1)](https://cabforum.org/wp-content/uploads/BRv1.2.3.pdf) require CAs to obtain agreement with a "Subscriber Agreement" or "Terms of Use" before they will issue a certificate.  We can reflect this requirement in ACME with a new challenge type that allows an applicant for authorization to agree to terms for the issuance of certs under that authorization. 
